### PR TITLE
Fix empty data checks for SignHandler

### DIFF
--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -47,9 +47,25 @@ func (mdb *mockDB) ListModels() ([]Model, error) {
 	return models, nil
 }
 
+func TestSignHandlerNilData(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/1.0/sign", nil)
+	http.HandlerFunc(SignHandler).ServeHTTP(w, r)
+
+	// Check the JSON response
+	result := SignResponse{}
+	err := json.NewDecoder(w.Body).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding the signed response: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected an error, got success response")
+	}
+}
+
 func TestSignHandlerNoData(t *testing.T) {
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("POST", "/v1/sign", nil)
+	r, _ := http.NewRequest("POST", "/1.0/sign", new(bytes.Buffer))
 	http.HandlerFunc(SignHandler).ServeHTTP(w, r)
 
 	// Check the JSON response


### PR DESCRIPTION
As you can see in the [documentation for http Request](https://golang.org/pkg/net/http/#Request), for server requests the Request Body is always non-nil, but will return EOF immediately when no body is present.

This commit checks for io.EOF **after** the response has been decoded (this will return io.EOF if the body was empty).

Also, return HTTP error codes when the format of the data is not correct.