### PR TITLE
Improved signing handler tests

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -159,7 +159,7 @@ func SignHandler(w http.ResponseWriter, r *http.Request) {
 	signedText, err := ClearSign(dataToSign, string(privateKey), "")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		errorMessage := fmt.Sprintf("Error signing the assertions: %v\n", err)
+		errorMessage := fmt.Sprintf("Error signing the assertions: %v", err)
 		formatSignResponse(false, errorMessage, "", w)
 		return
 	}


### PR DESCRIPTION
This is based on the branch I created (and we closed) about table driven tests.
Instead of creating a table, I have extracted functionality for calling the signing handler into a function.

Apart of that, for all tests, I have included a check for the right error message when expected.