### PR TITLE
Fix PSQL syntax error when creating the model table

### DIFF
--- a/service/modelmanager.go
+++ b/service/modelmanager.go
@@ -31,7 +31,7 @@ const createModelTableSQL = `
 		id          serial primary key not null,
 		brand_id    varchar(200) not null,
 		name        varchar(200) not null,
-		keypair_id  int references keypair not null,
+		keypair_id  int references keypair not null
 	)
 `
 const listModelsSQL = `


### PR DESCRIPTION
The trailing comma is giving a pg syntax error when creating the DB