### PR TITLE
Xpired nonces mgmt

### DIFF
--- a/service/database.go
+++ b/service/database.go
@@ -55,6 +55,7 @@ type Datastore interface {
 	SigningLogFilterValues() (SigningLogFilters, error)
 
 	CreateDeviceNonceTable() error
+	DeleteExpiredDeviceNonces() error
 	CreateDeviceNonce() (DeviceNonce, error)
 	ValidateDeviceNonce(nonce string) error
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -233,6 +233,12 @@ func RequestIDHandler(w http.ResponseWriter, r *http.Request) ErrorResponse {
 		return ErrorInvalidAPIKey
 	}
 
+	err = Environ.DB.DeleteExpiredDeviceNonces()
+	if err != nil {
+		logMessage("REQUESTID", "delete-expired-nonces", err.Error())
+		return ErrorGenerateNonce
+	}
+
 	nonce, err := Environ.DB.CreateDeviceNonce()
 	if err != nil {
 		logMessage("REQUESTID", "generate-request-id", err.Error())

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -44,14 +44,14 @@ func generatePrivateKey() (asserts.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func generateSerialRequestAssertion(model, serial, body string) (string, error) {
+func generateSerialRequestAssertion(requestID, model, serial, body string) (string, error) {
 	privateKey, _ := generatePrivateKey()
 	encodedPubKey, _ := asserts.EncodePublicKey(privateKey.PublicKey())
 
 	headers := map[string]interface{}{
 		"brand-id":   "System",
 		"device-key": string(encodedPubKey),
-		"request-id": "REQID",
+		"request-id": requestID,
 		"model":      model,
 	}
 
@@ -106,7 +106,7 @@ func TestSignHandlerInactive(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("inactive", "A123456L", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "inactive", "A123456L", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestSignHandler(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "A123456L", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "A123456L", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestSignHandlerSerialInBody(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "", "serial: A123456L")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "", "serial: A123456L")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestSignHandlerInvalidRequestID(t *testing.T) {
 	Environ = &Env{DB: &errorMockDB{}}
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "A123456L", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "A123456L", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -274,11 +274,36 @@ func TestSignHandlerInvalidRequestID(t *testing.T) {
 	sendRequestSignError(t, "POST", "/v1/serial", bytes.NewBufferString(assertions), "")
 }
 
+func TestSignHandlerExpiredNonce(t *testing.T) {
+	// Set up the API key
+	apiKeySlice := []string{"InbuiltAPIKey"}
+	apiKeys := make(map[string]struct{})
+	apiKeys["InbuiltAPIKey"] = struct{}{}
+
+	// Mock the database
+	config := ConfigSettings{KeyStoreType: "filesystem", KeyStorePath: "../keystore", APIKeys: apiKeySlice, APIKeysMap: apiKeys}
+	Environ = &Env{DB: &mockDB{}, Config: config}
+	Environ.KeypairDB, _ = GetKeyStore(config)
+
+	// Generate a test serial-request assertion
+	assertions, err := generateSerialRequestAssertion("REQID-expired", "alder", "A123456L", "")
+	if err != nil {
+		t.Errorf("Error creating serial-request: %v", err)
+	}
+
+	// Submit the serial-request assertion for signing
+	result, _ := sendRequestSignError(t, "POST", "/v1/serial", bytes.NewBufferString(assertions), "InbuiltAPIKey")
+	// Check that we have a assertion as a response
+	if result.ErrorCode != "invalid-nonce" {
+		t.Errorf("Expected an 'invalid nonce' message, got %s", result.ErrorCode)
+	}
+}
+
 func TestSignHandlerEmptySerial(t *testing.T) {
 	Environ = &Env{DB: &mockDB{}}
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -291,7 +316,7 @@ func TestSignHandlerNonExistentModel(t *testing.T) {
 	Environ = &Env{DB: &mockDB{}}
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("cannot-find-this", "A123456L", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "cannot-find-this", "A123456L", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -307,7 +332,7 @@ func TestSignHandlerDuplicateSigner(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "Aduplicate", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "Aduplicate", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -336,7 +361,7 @@ func TestSignHandlerCheckDuplicateError(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "AnError", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "AnError", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -351,7 +376,7 @@ func TestSignHandlerSigningLogError(t *testing.T) {
 	Environ.KeypairDB, _ = GetKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "AsigninglogError", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "AsigninglogError", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}
@@ -366,7 +391,7 @@ func TestSignHandlerErrorKeyStore(t *testing.T) {
 	Environ.KeypairDB, _ = getErrorMockKeyStore(config)
 
 	// Generate a test serial-request assertion
-	assertions, err := generateSerialRequestAssertion("alder", "A1234L", "")
+	assertions, err := generateSerialRequestAssertion("REQID", "alder", "A1234L", "")
 	if err != nil {
 		t.Errorf("Error creating serial-request: %v", err)
 	}

--- a/service/mock_database_test.go
+++ b/service/mock_database_test.go
@@ -234,7 +234,35 @@ func (mdb *mockDB) CreateDeviceNonce() (DeviceNonce, error) {
 	return DeviceNonce{Nonce: "1234567890", TimeStamp: 1234567890}, nil
 }
 
+func (mdb *mockDB) listDeviceNonces() ([]DeviceNonce, error) {
+
+	now := time.Now().Unix()
+	expired := now - nonceMaximumAge - 1
+
+	var nonces []DeviceNonce
+	nonces = append(nonces, DeviceNonce{ID: 1, Nonce: "REQID", TimeStamp: now})
+	nonces = append(nonces, DeviceNonce{ID: 2, Nonce: "REQID-expired", TimeStamp: expired})
+
+	return nonces, nil
+}
+
 func (mdb *mockDB) ValidateDeviceNonce(nonce string) error {
+
+	nonces, _ := mdb.listDeviceNonces()
+	found := false
+
+	expirationTime := time.Now().Unix() - nonceMaximumAge
+
+	for _, element := range nonces {
+		if element.Nonce == nonce && element.TimeStamp > expirationTime {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return errors.New("Cannot find the nonce in database")
+	}
 	return nil
 }
 

--- a/service/mock_database_test.go
+++ b/service/mock_database_test.go
@@ -234,35 +234,7 @@ func (mdb *mockDB) CreateDeviceNonce() (DeviceNonce, error) {
 	return DeviceNonce{Nonce: "1234567890", TimeStamp: 1234567890}, nil
 }
 
-func (mdb *mockDB) listDeviceNonces() ([]DeviceNonce, error) {
-
-	now := time.Now().Unix()
-	expired := now - nonceMaximumAge - 1
-
-	var nonces []DeviceNonce
-	nonces = append(nonces, DeviceNonce{ID: 1, Nonce: "REQID", TimeStamp: now})
-	nonces = append(nonces, DeviceNonce{ID: 2, Nonce: "REQID-expired", TimeStamp: expired})
-
-	return nonces, nil
-}
-
 func (mdb *mockDB) ValidateDeviceNonce(nonce string) error {
-
-	nonces, _ := mdb.listDeviceNonces()
-	found := false
-
-	expirationTime := time.Now().Unix() - nonceMaximumAge
-
-	for _, element := range nonces {
-		if element.Nonce == nonce && element.TimeStamp > expirationTime {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return errors.New("Cannot find the nonce in database")
-	}
 	return nil
 }
 

--- a/service/mock_database_test.go
+++ b/service/mock_database_test.go
@@ -226,6 +226,10 @@ func (mdb *mockDB) CreateDeviceNonceTable() error {
 	return nil
 }
 
+func (mdb *mockDB) DeleteExpiredDeviceNonces() error {
+	return nil
+}
+
 func (mdb *mockDB) CreateDeviceNonce() (DeviceNonce, error) {
 	return DeviceNonce{Nonce: "1234567890", TimeStamp: 1234567890}, nil
 }
@@ -335,6 +339,10 @@ func (mdb *errorMockDB) SigningLogFilterValues() (SigningLogFilters, error) {
 }
 
 func (mdb *errorMockDB) CreateDeviceNonceTable() error {
+	return nil
+}
+
+func (mdb *errorMockDB) DeleteExpiredDeviceNonces() error {
 	return nil
 }
 

--- a/service/noncemanager.go
+++ b/service/noncemanager.go
@@ -88,8 +88,8 @@ func (db *DB) CreateDeviceNonce() (DeviceNonce, error) {
 	return nonce, nil
 }
 
-// ValidateDeviceNonce checks that a device nonce is valid and has not expired
-func (db *DB) ValidateDeviceNonce(nonce string) error {
+// DeleteExpiredDeviceNonces removes nonces with timestamp older than max allowed lifetime
+func (db *DB) DeleteExpiredDeviceNonces() error {
 	// Remove expired nonces from the table
 	timestamp := time.Now().Unix() - nonceMaximumAge
 	_, err := db.Exec(deleteExpiredDeviceNonceSQL, timestamp)
@@ -98,6 +98,12 @@ func (db *DB) ValidateDeviceNonce(nonce string) error {
 		return errors.New("Error communicating with the database")
 	}
 
+	return nil
+}
+
+// ValidateDeviceNonce checks that a device nonce is valid and has not expired
+func (db *DB) ValidateDeviceNonce(nonce string) error {
+	db.DeleteExpiredDeviceNonces()
 	// Find the nonce in the database to check that it is valid (we already deleted expired nonces)
 	// Here we attempt to delete the nonce and check the number of rows affected. This makes sure that
 	// we do not allow a nonce to be re-used.

--- a/service/noncemanager.go
+++ b/service/noncemanager.go
@@ -108,7 +108,7 @@ func (db *DB) DeleteExpiredDeviceNonces() error {
 func (db *DB) ValidateDeviceNonce(nonce string) error {
 	err := db.DeleteExpiredDeviceNonces()
 	if err != nil {
-		log.Print("Error checking expired nonces: %v\n", err)
+		log.Printf("Error checking expired nonces: %v\n", err)
 		return err
 	}
 	// Find the nonce in the database to check that it is valid (we already deleted expired nonces)

--- a/service/noncemanager.go
+++ b/service/noncemanager.go
@@ -106,7 +106,11 @@ func (db *DB) DeleteExpiredDeviceNonces() error {
 
 // ValidateDeviceNonce checks that a device nonce is valid and has not expired
 func (db *DB) ValidateDeviceNonce(nonce string) error {
-	db.DeleteExpiredDeviceNonces()
+	err := db.DeleteExpiredDeviceNonces()
+	if err != nil {
+		log.Print("Error checking expired nonces: %v\n", err)
+		return err
+	}
 	// Find the nonce in the database to check that it is valid (we already deleted expired nonces)
 	// Here we attempt to delete the nonce and check the number of rows affected. This makes sure that
 	// we do not allow a nonce to be re-used.


### PR DESCRIPTION
Deletes expired nonces when received a request for a new nonce regardless the validation made when trying to use a nonce.
Not included tests as the only two that applies with current testing support are already implemented, by requesting a valid and a not valid nonce.