### PR TITLE
increased digits for random generated numbers up to 10 to pass the te…

### DIFF
--- a/service/utils_test.go
+++ b/service/utils_test.go
@@ -131,7 +131,7 @@ func TestRandomGeneration(t *testing.T) {
 	tokens := make(map[string]string)
 	for i := 0; i < n; i++ {
 		// generate minimum amount of random data to verify it is enough random
-		token, err := GenerateRandomString(1)
+		token, err := GenerateRandomString(10)
 		if err != nil {
 			t.Errorf("Error generating random string: %v", err)
 		}


### PR DESCRIPTION
- Test random numbers generation failed sometimes because it was asked 10 numbers of 1 digit. Now that's increased up to 10 digits per number to pass it always